### PR TITLE
Update coast

### DIFF
--- a/coast
+++ b/coast
@@ -57,13 +57,13 @@ EOF
   exit 0
 }
 
-if [ "$1" == "" ]
+if [ "$1" = "" ]
 then
   usage;
 fi
 
 # new <project name>
-if [ "$1" == "new" ]
+if [ "$1" = "new" ]
 then
   if [ "$2" != "" ]
   then


### PR DESCRIPTION
I followed the steps on the README with **coast** in `/usr/local/bin`.  When I ran `coast new myapp`, I got an error for an invalid operator.  The script in the project uses `==` to do string comparison, which is a bash thing and is invalid in POSIX sh.  I changed it to `=` so that it actually generates the project code.