### PR TITLE
Linux Install and sed command modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ curl -o /usr/local/bin/coast https://raw.githubusercontent.com/coast-framework/c
 sudo curl -o /usr/local/bin/coast https://raw.githubusercontent.com/coast-framework/coast/master/coast && sudo chmod a+x /usr/local/bin/coast
 ```
 
+
 3. Create a new coast project
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -8,16 +8,33 @@ Coast is a full stack web framework written in Clojure for small teams or solo d
 
 ## Getting Started
 
+### Installation on Mac
+
 1. Make sure clojure is installed first
 
-#### Mac
 ```bash
 brew install clojure
 ```
 
-#### Linux (Debian/Ubuntu)
+2. Install the coast cli script
+
 ```bash
-sudo apt-get install clojure
+curl -o /usr/local/bin/coast https://raw.githubusercontent.com/coast-framework/coast/master/coast && chmod a+x /usr/local/bin/coast
+```
+
+3. Create a new coast project
+
+```bash
+coast new myapp && cd myapp && make server
+```
+
+
+
+### Installation on Linux (Debian/Ubuntu)
+
+1. Make sure you have bash, curl, rlwrap, and Java installed
+
+```bash
 curl -O https://download.clojure.org/install/linux-install-1.9.0.391.sh
 chmod +x linux-install-1.9.0.391.sh
 sudo ./linux-install-1.9.0.391.sh
@@ -25,16 +42,9 @@ sudo ./linux-install-1.9.0.391.sh
 
 2. Install the coast cli script
 
-#### Mac
-```bash
-curl -o /usr/local/bin/coast https://raw.githubusercontent.com/coast-framework/coast/master/coast && chmod a+x /usr/local/bin/coast
-```
-
-#### Linux (Debian/Ubuntu)
 ```bash
 sudo curl -o /usr/local/bin/coast https://raw.githubusercontent.com/coast-framework/coast/master/coast && sudo chmod a+x /usr/local/bin/coast
 ```
-
 
 3. Create a new coast project
 
@@ -44,6 +54,7 @@ coast new myapp && cd myapp && make server
 
 You should be greeted with the text "You're coasting on clojure!"
 when you visit `http://localhost:1337`
+
 
 ## Read The Docs
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,29 @@ Coast is a full stack web framework written in Clojure for small teams or solo d
 
 1. Make sure clojure is installed first
 
+#### Mac
 ```bash
 brew install clojure
 ```
 
+#### Linux (Debian/Ubuntu)
+```bash
+sudo apt-get install clojure
+curl -O https://download.clojure.org/install/linux-install-1.9.0.391.sh
+chmod +x linux-install-1.9.0.391.sh
+sudo ./linux-install-1.9.0.391.sh
+```
+
 2. Install the coast cli script
 
+#### Mac
 ```bash
 curl -o /usr/local/bin/coast https://raw.githubusercontent.com/coast-framework/coast/master/coast && chmod a+x /usr/local/bin/coast
+```
+
+#### Linux (Debian/Ubuntu)
+```bash
+sudo curl -o /usr/local/bin/coast https://raw.githubusercontent.com/coast-framework/coast/master/coast && sudo chmod a+x /usr/local/bin/coast
 ```
 
 3. Create a new coast project

--- a/coast
+++ b/coast
@@ -57,13 +57,13 @@ EOF
   exit 0
 }
 
-if [ "$1" == "" ]
+if [ "$1" = "" ]
 then
   usage;
 fi
 
 # new <project name>
-if [ "$1" == "new" ]
+if [ "$1" = "new" ]
 then
   if [ "$2" != "" ]
   then

--- a/coast
+++ b/coast
@@ -78,9 +78,17 @@ then
     cd $2
     mv gitignore .gitignore
     for f in $(find . -type f) ; do
-      sed -i '' "s/{{name}}/$name/g" $f
-      sed -i '' "s/{{sanitized}}/$sanitized/g" $f
-      sed -i '' "s/{{secret}}/$secret/g" $f
+      if [ $(uname) = "Darwin" ] # Mac
+      then
+        sed -i '' "s/{{name}}/$name/g" $f
+        sed -i '' "s/{{sanitized}}/$sanitized/g" $f
+        sed -i '' "s/{{secret}}/$secret/g" $f
+      elif [ $(uname) = "Linux" ]
+      then
+        sed -i "s/{{name}}/$name/g" $f
+        sed -i "s/{{sanitized}}/$sanitized/g" $f
+        sed -i "s/{{secret}}/$secret/g" $f
+      fi
     done
 
     echo "Created a new coast project in directory $2"


### PR DESCRIPTION
I updated the README to include installation instructions for people who are using Linux, particularly Debian/Ubuntu.  Also, I updated the coast script to remove the single quotes after the `-i` flag for Linux and kept it for Mac.  When generating the project using `coast new myapp`, I get the project, but I also got so many errors having to do with sed along the lines of `sed: can't read : No such file or directory`.  Apparently, the `-i` flag works differently for GNU sed and Mac sed.  [https://stackoverflow.com/a/43453459](This) StackOverflow post explains more about that issue.  