### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,13 +208,6 @@ make server
 and visit `http://localhost:1337/todos` to see the app in action.
 
 #### From the REPL
-Navigate to the `src/server.clj` file and type this below the `(defn -main)` part:
-
-```clojure
-(comment
-  (-main))
-```
-
 I currently use [proto-repl](https://github.com/jasongilman/proto-repl), check it out if you want a smooth clojure REPL experience.
 
 First run, the nrepl server:

--- a/README.md
+++ b/README.md
@@ -190,10 +190,7 @@ One thing coast doesn't do yet is update the routes file, let's do that now:
   (coast/site
     (coast/with-layout :components/layout
       [:get "/" :home/index]
-      [:resource :todo] ; add this line
-
-    [:404 :home/not-found]
-    [:500 :home/server-error])))
+      [:resource :todo] ; add this line)))
 ```
 
 The routes are also clojure vectors, with each element of the route indicating which http method, url and function to call, along with an optional route name if you don't like the `namespace`/`function` name.


### PR DESCRIPTION
Remove 404 and 500 errors from routes.clj as per 4/24/19 update post.
 I just started a test project, and that was the first outdated README snippet I found. I would like to help out with this project in a more substantial way going forward! 