### PR TITLE
Load db/migrations from the resource

### DIFF
--- a/src/coast/migrations.clj
+++ b/src/coast/migrations.clj
@@ -12,8 +12,11 @@
 
 
 (defn migrations-dir []
-  (.mkdirs (File. "db/migrations"))
-  "db/migrations")
+  (or
+    (io/resource "db/migrations")
+    (do
+      (.mkdirs (File. "db/migrations"))
+      "db/migrations")))
 
 
 (defn migration-files []


### PR DESCRIPTION
Relate to [Cannot run db migration with the uberjar](https://github.com/coast-framework/template/issues/5)