### PR TITLE
Document top-level APIs

### DIFF
--- a/src/coast/components.clj
+++ b/src/coast/components.clj
@@ -4,14 +4,18 @@
             [coast.assets :as assets]))
 
 (defn csrf
+  "Return a hidden input with the csrf token."
   ([attrs]
-   [:input (assoc attrs :type "hidden"
-                        :name "__anti-forgery-token"
-                        :value *anti-forgery-token*)])
+   [:input (assoc attrs
+                  :type "hidden"
+                  :name "__anti-forgery-token"
+                  :value *anti-forgery-token*)])
   ([]
    (csrf {})))
 
-(defn form [params & body]
+(defn form
+  "Return a form with the hidden input already added to the body"
+  [params & body]
   [:form (dissoc params :_method)
    (csrf)
    (when (contains? #{:patch :put :delete} (:_method params))
@@ -19,6 +23,23 @@
    body])
 
 (defn css
+  "Adds a link tag to a CSS bundle.
+
+  Relative path (to CSS files in the public directory):
+
+  ```clojure
+  (coast/css \"bundle.css\")
+
+  ; assuming the assets.edn looks something like this
+  {\"bundle.css\" [\"style.css\"]}
+  ```
+
+  The code above outputs:
+
+  ```html
+  <link rel=\"stylesheet\" href=\"/style.css\" />
+  ```
+  "
   ([req bundle opts]
    (let [files (assets/bundle (env :coast-env) bundle)]
      (for [href files]
@@ -29,10 +50,26 @@
    (css nil bundle)))
 
 (defn js
+  "Adds a script tag to a JS bundle.
+
+  ```clojure
+  (coast/js \"bundle.js\")
+
+  ; assuming the assets.edn looks something like this
+  {\"bundle.js\" [\"app.js\" \"app2.js\"]}
+  ```
+
+  The code above outputs:
+
+  ```html
+  <script type=\"text/javascript\" src=\"/app.js\" />
+  <script type=\"text/javascript\" src=\"/app2.js\" />
+  ```
+  "
   ([req bundle opts]
    (let [files (assets/bundle (env :coast-env) bundle)]
      (for [src files]
-      [:script (merge {:src src :type "application/javascript"} opts)])))
+       [:script (merge {:src src :type "application/javascript"} opts)])))
   ([req bundle]
    (js nil bundle {}))
   ([bundle]

--- a/src/coast/db.clj
+++ b/src/coast/db.clj
@@ -390,7 +390,7 @@
   (->> (map #(upsert-rel parent %) m)
        (into {})))
 
-(defn transact [m]
+(defn transact
   "This function resolves foreign keys (or hydrates), it also deletes related rows based on idents as well as inserting and updating rows.
 
   Here are some concrete examples:
@@ -445,25 +445,25 @@
 
   (db/transact {:author/id 2
                 :author/posts []})"
-
-  (let [k-ns (->> m keys (filter qualified-ident?) first namespace)
-        s-rels (select-rels m)
+  [m]
+  (let [k-ns          (->> m keys (filter qualified-ident?) first namespace)
+        s-rels        (select-rels m)
         s-rel-results (resolve-select-rels s-rels) ; foreign keys
-        m-rels (many-rels m)
-        m* (merge m s-rel-results)
-        m* (apply dissoc m* (keys m-rels))
-        row (when (not (empty? (db.update/idents (map identity m*))))
-              (->> (db.update/sql-vec m*)
-                   (query (connection))
-                   (map #(qualify-map k-ns %))
-                   (single)))
-        row (if (empty? row)
-              (->> (db.insert/sql-vec m*)
-                   (query (connection))
-                   (map #(qualify-map k-ns %))
-                   (single))
-              row)
-        rel-rows (upsert-rels row m-rels)]
+        m-rels        (many-rels m)
+        m*            (merge m s-rel-results)
+        m*            (apply dissoc m* (keys m-rels))
+        row           (when (not (empty? (db.update/idents (map identity m*))))
+                        (->> (db.update/sql-vec m*)
+                             (query (connection))
+                             (map #(qualify-map k-ns %))
+                             (single)))
+        row           (if (empty? row)
+                        (->> (db.insert/sql-vec m*)
+                             (query (connection))
+                             (map #(qualify-map k-ns %))
+                             (single))
+                        row)
+        rel-rows      (upsert-rels row m-rels)]
     (merge row rel-rows)))
 
 (defn insert

--- a/src/coast/db/connection.clj
+++ b/src/coast/db/connection.clj
@@ -17,7 +17,7 @@
    (get (spec) k)))
 
 
-(def datasource-class-names {"sqlite" "org.sqlite.SQLiteDataSource"
+(def datasource-class-names {"sqlite"   "org.sqlite.SQLiteDataSource"
                              "postgres" "org.postgresql.ds.PGSimpleDataSource"})
 
 
@@ -65,7 +65,10 @@
 
 (def pooled-db (atom (delay (pool (spec)))))
 
-(defn connection [] @(deref pooled-db))
+(defn connection
+  "Return a database connection."
+  []
+  @(deref pooled-db))
 
 (defn reconnect! []
   (reset! pooled-db (delay (pool (spec)))))

--- a/src/coast/error.clj
+++ b/src/coast/error.clj
@@ -1,21 +1,30 @@
-(ns coast.error)
+(ns coast.error
+  "Regular exceptions leave little to be desired. raise and rescue are wrappers around ExceptionInfo")
 
 (defn raise
+  "Raise an instance of ExceptionInfo with a map `m` and an optional message `s`."
   ([s m]
    (throw (ex-info s (assoc m ::raise true))))
   ([m]
    (raise "Error has occurred" m)))
 
 (defmacro rescue
-  "Regular exceptions leave little to be desired. raise and rescue are wrappers around ExceptionInfo"
+  "Evaluate the form `f` and returns a two-tuple vector of `[result error]`.
+  Any exception thrown by form `f` will be caught and return in the `error`.
+  Otherwise `error` will be `nil`.
+
+  When the exception contains the raise keyword `:coast.error/raise`,
+  `rescue` will not catch the error.
+
+  You can customize the raise keyword by using the optional `k` argument."
   ([f k]
    `(try
-     [~f nil]
-     (catch clojure.lang.ExceptionInfo e#
-       (let [ex# (ex-data e#)]
-         (if (and (contains? ex# ::raise)
-                  (contains? ex# (or ~k ::raise)))
-           [nil ex#]
-           (throw e#))))))
+      [~f nil]
+      (catch clojure.lang.ExceptionInfo e#
+        (let [ex# (ex-data e#)]
+          (if (and (contains? ex# ::raise)
+                   (contains? ex# (or ~k ::raise)))
+            [nil ex#]
+            (throw e#))))))
   ([f]
    `(rescue ~f nil)))

--- a/src/coast/middleware.clj
+++ b/src/coast/middleware.clj
@@ -219,7 +219,9 @@
     :else nil))
 
 
-(defn wrap-layout [handler layout]
+(defn wrap-layout
+  "Return the middleware that wraps the response with a layout function `layout`."
+  [handler layout]
   (fn [request]
     (let [response (handler request)]
       (if (vector? response)
@@ -230,19 +232,27 @@
         response))))
 
 
-(defn wrap-with-layout [layout & routes]
+(defn wrap-with-layout
+  "Wraps the given set of routes with the layout function."
+  [layout & routes]
   (let [layout-fn (resolve-fn layout)]
     (if (nil? layout-fn)
       (throw (Exception. "with-layout requires a layout function in the first argument"))
       (router/wrap-routes #(wrap-layout % layout-fn) routes))))
 
 
-(defn with-layout [layout & routes]
+(defn with-layout
+  "Short for `wrap-with-layout`."
+  [layout & routes]
   (apply (partial wrap-with-layout layout) routes))
 
 
-(defn content-type? [m k]
-  (let [headers (utils/map-keys string/lower-case (:headers m))
+(defn content-type?
+  "Check whether a request or response map `m` has the content type of `k`.
+
+  `k` can be either `:html` or `:json`."
+  [m k]
+  (let [headers      (utils/map-keys string/lower-case (:headers m))
         content-type (get headers "content-type" "")]
     (condp = k
       :html (string/starts-with? content-type "text/html")
@@ -278,17 +288,21 @@
         :else (throw (Exception. "You can only return vectors, maps and strings from handler functions"))))))
 
 
-(defn site-routes [& args]
+(defn site-routes
+  "Wraps the given set of routes with the middlewares for site routes."
+  [& args]
   (let [[opts routes] (if (map? (first args))
                         [(first args) (rest args)]
                         [{} args])
-        opts (site-defaults opts)]
+        opts          (site-defaults opts)]
     (router/wrap-routes #(site-middleware % opts)
                         ring-response-html
                         routes)))
 
 
-(defn site [& args]
+(defn site
+  "Short for `site-routes`."
+  [& args]
   (apply site-routes args))
 
 
@@ -402,11 +416,15 @@
         :else (throw (Exception. "You can only return vectors, maps and strings from handler functions"))))))
 
 
-(defn api-routes [& routes]
+(defn api-routes
+  "Wraps the given set of routes with the middlewares for api routes."
+  [& routes]
   (router/wrap-routes ring-response-json routes))
 
 
-(defn api [& routes]
+(defn api
+  "Short for `api-routes`."
+  [& routes]
   (apply api-routes routes))
 
 

--- a/src/coast/responses.clj
+++ b/src/coast/responses.clj
@@ -14,7 +14,9 @@
   ([status body]
    (response status body {})))
 
-(defn flash [response s]
+(defn flash
+  "Inject a string `s` that will be persistent after the redirect."
+  [response s]
   (assoc response :flash s))
 
 (defn redirect

--- a/src/coast/responses.clj
+++ b/src/coast/responses.clj
@@ -17,9 +17,11 @@
 (defn flash [response s]
   (assoc response :flash s))
 
-(defn redirect [url]
-  {:status 302
-   :body ""
+(defn redirect
+  "Return a Ring response map with status code 302 and url `url`"
+  [url]
+  {:status  302
+   :body    ""
    :headers {"Location" url}})
 
 (def ok

--- a/src/coast/responses.clj
+++ b/src/coast/responses.clj
@@ -22,12 +22,38 @@
    :body ""
    :headers {"Location" url}})
 
-(def ok (partial response 200))
-(def created (partial response 201))
-(def accepted (partial response 202))
-(def no-content (partial response 204))
-(def bad-request (partial response 400))
-(def unauthorized (partial response 401))
-(def not-found (partial response 404))
-(def forbidden (partial response 403))
-(def server-error (partial response 500))
+(def ok
+  "Return a Ring response map with status code 200"
+  (partial response 200))
+
+(def created
+  "Return a Ring response map with status code 201"
+  (partial response 201))
+
+(def accepted
+  "Return a Ring response map with status code 202"
+  (partial response 202))
+
+(def no-content
+  "Return a Ring response map with status code 204"
+  (partial response 204))
+
+(def bad-request
+  "Return a Ring response map with status code 400"
+  (partial response 400))
+
+(def unauthorized
+  "Return a Ring response map with status code 401"
+  (partial response 401))
+
+(def not-found
+  "Return a Ring response map with status code 404"
+  (partial response 404))
+
+(def forbidden
+  "Return a Ring response map with status code 403"
+  (partial response 403))
+
+(def server-error
+  "Return a Ring response map with status code 500"
+  (partial response 500))

--- a/src/coast/router.clj
+++ b/src/coast/router.clj
@@ -249,7 +249,9 @@
     (mapv #(wrap-route % fns) routes)))
 
 
-(defn with [& args]
+(defn with
+  "Wraps a given set of routes in the given functions"
+  [& args]
   (apply wrap-routes args))
 
 
@@ -431,14 +433,18 @@
     (update route 1 #(str s %))
     route))
 
-(defn prefix-routes [s & routes]
+(defn prefix-routes
+  "Prefix routes with a string `s`."
+  [s & routes]
   (if (and (= 1 (count routes))
            (routes? (first routes)))
     (mapv #(prefix-route s %) (first routes))
     (mapv #(prefix-route s %) routes)))
 
 
-(defn with-prefix [& args]
+(defn with-prefix
+  "Prefix routes with a string `s`."
+  [& args]
   (apply prefix-routes args))
 
 
@@ -446,7 +452,11 @@
   (println (string/join "\n" (map pretty-route routes))))
 
 
-(defn routes [& args]
+(defn routes
+  "Assembles routes into a single vector.
+
+  Any route resource is expended into the normalized routes."
+  [& args]
   (->> (flatten-wrapped-routes args)
        (mapcat expand-resource)
        (filter #(not (resource-route? %)))

--- a/src/coast/theta.clj
+++ b/src/coast/theta.clj
@@ -111,7 +111,9 @@
 
 
 (defn url-for
-  "Creates a url from a route name"
+  "Creates a url from a route name
+
+  (This function requires `coast/app` to be invoked first.)"
   ([k m]
    (if-let [anchor (:# m)]
      (str ((router/url-for-routes routes) k (dissoc m :#)) "#" (name anchor))
@@ -121,22 +123,33 @@
 
 
 (defn action-for
+  "Return an attribute map to perform a form action for route `k`.
+
+  (This function requires `coast/app` to be invoked first.)"
   ([k m]
    ((router/action-for-routes routes) k m))
   ([k]
    (action-for k {})))
 
 
-(defn redirect-to [& args]
-  {:status 302
-   :body ""
+(defn redirect-to
+  "Return a response map that redirects to route.
+
+  (This function requires `coast/app` to be invoked first.)"
+  [& args]
+  {:status  302
+   :body    ""
    :headers {"Location" (apply url-for args)}})
 
 
-(defn form-for [k & body]
-  (let [m (if (map? (first body))
-            (first body)
-            {})
+(defn form-for
+  "Return a form hiccup element that performs action for route `k`.
+
+  (This function requires `coast/app` to be invoked first.)"
+  [k & body]
+  (let [m    (if (map? (first body))
+               (first body)
+               {})
         body (if (map? (first body))
                (rest body)
                body)
@@ -146,4 +159,4 @@
                (drop 1 body)
                body)]
     (coast.components/form (merge (action-for k m) opts)
-      body)))
+                           body)))

--- a/src/coast/time2.clj
+++ b/src/coast/time2.clj
@@ -3,15 +3,20 @@
            (java.time.format DateTimeFormatter)))
 
 
-(defn now []
+(defn now
+  "Return the current time (in epoch second)."
+  []
   (.getEpochSecond (Instant/now)))
 
 
-(defn instant [seconds]
+(defn instant
+  "Convert epoch second `second` to `java.time.Instant`."
+  [seconds]
   (Instant/ofEpochSecond seconds))
 
 
 (defn datetime
+  "Convert epoch second `second` to `java.time.ZonedDateTime`."
   ([seconds zone]
    (let [zoneId (if (string? zone)
                   (ZoneId/of zone)
@@ -23,6 +28,8 @@
    (datetime seconds nil)))
 
 
-(defn strftime [d pattern]
+(defn strftime
+  "Convert datetime `d` to str with pattern `pattern`."
+  [d pattern]
   (let [formatter (DateTimeFormatter/ofPattern pattern)]
     (.format formatter d)))

--- a/src/coast/utils.clj
+++ b/src/coast/utils.clj
@@ -5,6 +5,7 @@
 
 
 (defn uuid
+  "Return a random UUID."
   ([]
    (UUID/randomUUID))
   ([s]
@@ -183,10 +184,12 @@
          (first))
     s))
 
-(defn intern-var [name value]
+(defn intern-var
+  "Intern a var in the current name space."
+  [name value]
   (intern *ns*
           (with-meta (symbol name)
-                     (meta value))
+            (meta value))
           value))
 
 
@@ -212,7 +215,9 @@
   (.encodeToString (Base64/getEncoder) (gen-bytes size)))
 
 
-(defn xhr? [request]
+(defn xhr?
+  "Check if a request map `request` has the \"X-Requested-With\" header."
+  [request]
   (contains? (:headers request) "x-requested-with"))
 
 

--- a/src/coast/validation.clj
+++ b/src/coast/validation.clj
@@ -14,12 +14,35 @@
          (mapcat identity)
          (into {}))))
 
-(defn validate [m validations]
+(defn validate
+  "Validate the map `m` with a vector of rules `validations`.
+
+  For example:
+  ```
+  (validate {:customer/id 123
+             :customer/email \"sean@example.com\"}
+            [[:required [:customer/id :customer/email]]
+             [:email [:customer/email]]])
+  ;; => {:customer/id 123
+         :customer/email \"sean@example.com\"}
+
+  (validate {} [[:required [:customer/id] \"can't be blank\"]])
+  ;; => Unhandled clojure.lang.ExceptionInfo
+  ;;    Invalid data: :customer/id
+  ;;    {:type :invalid,
+  ;;     :errors #:customer{:id \"Id can't be blank\"},
+  ;;     :coast.validation/error :validation,
+  ;;     :coast.error/raise true}
+  ```
+
+  See [Validator](https://coastonclojure.com/docs/validator.md) for more.
+  "
+  [m validations]
   (let [errors (-> (v/validate m validations)
                    (fmt-validations))]
     (if (empty? errors)
       m
       (raise (str "Invalid data: " (string/join ", " (keys errors)))
-             {:type :invalid
+             {:type   :invalid
               :errors errors
               ::error :validation}))))

--- a/test/coast_test.clj
+++ b/test/coast_test.clj
@@ -135,3 +135,9 @@
     (testing "delete request"
       (is (= "i'm a delete"
              (:body (app {:request-method :delete :uri "/"})))))))
+
+(deftest top-level-documents-test
+  (doseq [var (-> (ns-publics 'coast)
+                  vals)]
+    (testing (str var " has docs")
+      (is (some? (-> var meta :doc))))))


### PR DESCRIPTION
This PR addresses #84.
Add a documentation test to ensure top-level APIs have docs.

This is the documentation progress:

`coast.responses`
* - [x] ok
* - [x] bad-request
* - [x] not-found
* - [x] unauthorized
* - [x] server-error
* - [x] redirect
* - [x] flash

`coast.error`
* - [x] raise
* - [x] rescue

`coast.db`
* - [x] q
* - [x]    pull
* - [x]    transact
* - [x]    delete
* - [x]    insert
* - [x]    update
* - [x]    first!
* - [x]    pluck
* - [x]    fetch
* - [x]    execute!
* - [x]    find-by
* - [x]    transaction

`coast.db.connection`
* - [x]    connection

`coast.validation`
* - [x]    validate

`coast.components`
* - [x]    csrf
* - [x]    form
* - [x]    js
* - [x]    css

`coast.router`
* - [x]    routes
* - [x]    wrap-routes
* - [x]    prefix-routes
* - [x]    with
* - [x]    with-prefix

`coast.middleware`
* - [x]    wrap-with-layout
* - [x]    with-layout
* - [x]    wrap-layout
* - [x]    site-routes
* - [x]    site
* - [x]    api-routes
* - [x]    api
* - [x]    content-type?

`coast.theta`
* - [x]    server
* - [x]    app
* - [x]    url-for
* - [x]    action-for
* - [x]    redirect-to
* - [x]    form-for

`coast.env`
* - [x]    env

`coast.jobs`
* - [x]    queue

`coast.utils`
* - [x]    uuid
* - [x]    intern-var
* - [x]    xhr?

`coast.time2`
* - [x]    now
* - [x]    datetime
* - [x]    instant
* - [x]    strftime

`hiccup2.core`
* - [x]    raw
* - [x]    html