### PR TITLE
Improve postgres db creation by specifying more args

### DIFF
--- a/src/coast/db.clj
+++ b/src/coast/db.clj
@@ -91,7 +91,7 @@
       (presence (spec spec-name))))
 
 (defn create-postgres-command
-  "Generates the vector that makes up the clojure command."
+  "Generates the vector that makes up the createdb command."
   [database]
   (let [host (env|spec "PGHOST" :host)
         port (env|spec "PGPORT" :port)


### PR DESCRIPTION
The current db create make task wasn't using the db configuration
for anything but the db name and so the command would fail if it
required login or the db was on another host (like in docker).
These changes make it use values from the environment and then
fall back to using values from the config in order to specify
arguments to createdb.

Postgres env vars were borrowed from:
https://www.postgresql.org/docs/12/libpq-envars.html