### PR TITLE
Set LANG=c when generating secret

### DIFF
--- a/coast
+++ b/coast
@@ -32,7 +32,7 @@ snakecase() {
 }
 
 random() {
-  echo $(LC_CTYPE=C tr -dc A-Za-z0-9 < /dev/urandom | fold -w ${1:-16} | head -n 1)
+  echo $(LC_CTYPE=C LANG=C tr -dc A-Za-z0-9 < /dev/urandom | fold -w ${1:-16} | head -n 1)
 }
 
 # help


### PR DESCRIPTION
## What's the problem?
The character type in Monterey appears to be set to an unexpected value, causing the `coast` script to raise an errer when attempting to generate a random secret.

On my system, LANG was set to 'en_CA.UTF-8'. When piping the output of /dev/urandom to `fold`, a message 'Input error' appears and an empty string is returned and set as the "secret". ie, any place that we expect to have a random secret set for our app will actually have an empty string!

This change is the quickest fix I could think of to correct this. Another option would be to set LC_CTYPE to `en.US.UTF-8`, but I'm not sure if this is compatible on other systems.

## Steps to reproduce
You should be able to reproduce this reliably with the following:
```bash
LC_CTYPE=C LANG=en_CA.UTF-8 tr -dc "a-zA-Z0-9-_\$\?" < /dev/urandom | fold -w 16 | head -1
```
You should see something like the following:

<img width="776" alt="Screen Shot 2022-04-06 at 8 38 47 AM" src="https://user-images.githubusercontent.com/150988/162000640-f18b9c65-98d7-401b-8dd8-6cfd91689e58.png">

**Note: you could replace this line in wherever you've installed your coast script to see the effects this when generating a new project.** If you do this, then a project will still be generated, but every place that should contain this randomly-generated string will instead have an empty string assigned, like `env.edn` which will have content like:
```Clojure
{:coast-env "dev"
 :port 1337
 :session-key ""}
```

