### PR TITLE
Fix failing format for .sql migrations.

### DIFF
--- a/src/coast/generators/migration.clj
+++ b/src/coast/generators/migration.clj
@@ -30,7 +30,7 @@
 
 (defn contents [mig-type ts mig-name args]
   (condp = mig-type
-    :sql (str "-- up:\n\n-- down:")
+    :sql (str "-- up\n\n-- down")
     :edn (str "[]")
     :clj (clj-contents ts mig-name args)
     ""))


### PR DESCRIPTION
When using `coast gen migration *.sql`, a file is generated of the form:
```sql
-- up:

-- down:
```
When this migration is run - say, via `make db/migrate` - the migration fails with the error:

> Exception in thread "main" `java.sql.BatchUpdateException`: batch entry 0: `[SQLITE_ERROR]` SQL error or missing database (unrecognized token: "`:`")

This is resolved by removing the colons from the migration direction pragmas.