### PR TITLE
Allow verily validations to be fully leveraged.

### DIFF
--- a/src/coast/validation.clj
+++ b/src/coast/validation.clj
@@ -15,7 +15,9 @@
          (into {}))))
 
 (defn validate
-  "Validate the map `m` with a vector of rules `validations`.
+  "Validate the map `m` with a vector of rules `validations`,
+  or a validation fn, such as that created with verily's
+  `combine`.
 
   For example:
   ```
@@ -38,8 +40,10 @@
   See [Validator](https://coastonclojure.com/docs/validator.md) for more.
   "
   [m validations]
-  (let [errors (-> (v/validate m validations)
-                   (fmt-validations))]
+  (let [errors (fmt-validations
+                 (if (fn? validations)
+                   (validations m)
+                   (v/validate m validations)))]
     (if (empty? errors)
       m
       (raise (str "Invalid data: " (string/join ", " (keys errors)))


### PR DESCRIPTION
Currently, coast's validations only permits vector form of verily validations. This makes it impossible to directly use custom validations, including domain-specific validations; or to compose validations, such as would be possible via verily's `combine` function - especially useful when large parts of a validation are shared between creation and update endpoints.

By checking for a function as the input validations, it may be possible to permit the full scope of verily's 'custom validator fn' functionality and its composing functionality. This does not validate the shape of the fn as of yet, so further constraints may be desirable before merging.